### PR TITLE
fix: add log index log_daterecieved

### DIFF
--- a/LIQUIBASE/changelog/db-changelog-master.xml
+++ b/LIQUIBASE/changelog/db-changelog-master.xml
@@ -19,5 +19,6 @@
     <include file="\v5.3.8\db-changelog_add_additional_ref_to_log.xml" relativeToChangelogFile="true"/>
     <include file="\v5.3.8\db-changelog_add_unsent_message_resend_parameter.xml" relativeToChangelogFile="true"/>
     <include file="\v5.3.27\db-changelog_add_unsent_message_acknowledged.xml" relativeToChangelogFile="true"/>
+    <include file="\v5.3.32\db-changelog_add_log_index_log_daterecieved.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/LIQUIBASE/changelog/v5.3.32/db-changelog_add_log_index_log_daterecieved.xml
+++ b/LIQUIBASE/changelog/v5.3.32/db-changelog_add_log_index_log_daterecieved.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd"
+                   logicalFilePath="changelog/v5.2.32/db-changelog_add_log_index_log_daterecieved.xml">
+
+    <changeSet author="johwal" id="Add index on log_daterecieved">
+        <createIndex indexName="log_log_daterecieved_idx"
+                     tableName="log">
+            <column name="log_daterecieved"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Since there's a foreign key towards the log table, changing it to a partitioned table instead becomes very complicated. Adding an index might be good enough for now.

Refs: FART-547